### PR TITLE
Add Asqav to Agent Governance Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ AI agents are moving from demos to production, but governance hasn't kept up. Th
 - [Coral Server](https://github.com/Coral-Protocol/coral-server) - Agent coordination and trust server enabling safe multi-agent collaboration with structured communication protocols.
 - [LiteLLM](https://github.com/BerriAI/litellm) - Unified LLM gateway with spend tracking, rate limiting, guardrails, and access controls across 100+ LLM providers.
 - [Invariant Guardrails](https://github.com/invariantlabs-ai/invariant) - Rule-based guardrails engine for agentic applications with policy-as-code, trace analysis, and real-time intervention.
+- [Asqav](https://github.com/jagmarques/asqav-sdk) - Python SDK for AI agent governance with tamper-evident audit trails, tool scanning, and runtime enforcement policies. Integrates with LangChain, CrewAI, OpenAI Agents SDK, Haystack, LiteLLM, and MCP.
 
 ## LLM Safety & Guardrails
 


### PR DESCRIPTION
Adds Asqav to the Agent Governance Frameworks section.

Asqav is an open-source Python SDK that adds a governance layer to existing AI agent stacks. It fits this list because it focuses on the runtime governance problems the list covers: tamper-evident audit trails for agent actions, tool scanning to catch risky tool definitions before they run, and policy enforcement at the action level.

- Repo: https://github.com/jagmarques/asqav-sdk
- PyPI: pip install asqav
- License: MIT
- Integrations: LangChain, CrewAI, OpenAI Agents SDK, Haystack, LiteLLM, MCP

Use cases include producing evidence auditors can verify for frameworks like the EU AI Act Article 12 and ISO/IEC 42001.

Happy to adjust the description or move the entry to a different subsection if you prefer.