### PR TITLE
Add Commit — supply chain trust scoring for npm, PyPI, Cargo, Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 
 *Scanners, red-teaming tools, and frameworks for testing the security of AI agents and LLMs.*
 
-- [Commit](https://getcommit.dev) - Supply chain trust scoring for npm, PyPI, Cargo, and Go packages. Scores single-maintainer concentration, OIDC gaps, and release consistency — surfacing high-risk dependency patterns that vulnerability databases miss. CLI, GitHub Action, IDE hooks, REST API, and MCP server. Demonstrated predictive scoring on axios and node-ipc before attacks occurred.
+- [Commit](https://getcommit.dev) - Supply chain trust scoring for npm, PyPI, Cargo, and Go packages. Scores maintainer concentration, OIDC publisher gaps, and release consistency to surface high-risk dependency patterns that vulnerability databases miss. CLI, GitHub Action, IDE hooks, REST API, and MCP server.
 - [Counterfit](https://github.com/Azure/counterfit) - Azure's tool for assessing ML model security through adversarial attacks.
 - [CyberSecEval](https://github.com/meta-llama/PurpleLlama/tree/main/CybersecurityBenchmarks) - Meta's benchmark suite for LLM cybersecurity risks including insecure code generation and prompt extraction.
 - [Garak](https://github.com/NVIDIA/garak) - LLM vulnerability scanner from NVIDIA. Probes for hallucination, data leakage, prompt injection, toxicity, and more.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 
 *Scanners, red-teaming tools, and frameworks for testing the security of AI agents and LLMs.*
 
+- [Commit](https://getcommit.dev) - Supply chain trust scoring for npm, PyPI, Cargo, and Go packages. Scores single-maintainer concentration, OIDC gaps, and release consistency — surfacing high-risk dependency patterns that vulnerability databases miss. CLI, GitHub Action, IDE hooks, REST API, and MCP server. Demonstrated predictive scoring on axios and node-ipc before attacks occurred.
 - [Counterfit](https://github.com/Azure/counterfit) - Azure's tool for assessing ML model security through adversarial attacks.
 - [CyberSecEval](https://github.com/meta-llama/PurpleLlama/tree/main/CybersecurityBenchmarks) - Meta's benchmark suite for LLM cybersecurity risks including insecure code generation and prompt extraction.
 - [Garak](https://github.com/NVIDIA/garak) - LLM vulnerability scanner from NVIDIA. Probes for hallucination, data leakage, prompt injection, toxicity, and more.


### PR DESCRIPTION
## What this adds

[Commit](https://getcommit.dev) — a registry-level supply chain trust scoring platform covering npm, PyPI, Cargo, and Go packages.

## Why it belongs here

AI agents are built with dependencies. Supply chain attacks (axios, node-ipc) have shown that vulnerability databases alone miss behavioral signals — single-maintainer concentration, OIDC gaps, release inconsistency — that predict compromise. Commit surfaces exactly these patterns before they become incidents.

## Placement

Added to **Security Testing** as a supply chain scanner. Fits alongside Snyk Agent Scan and Garak — tools that assess the security posture of the components agents depend on.

## Entry

```
- [Commit](https://getcommit.dev) - Supply chain trust scoring for npm, PyPI, Cargo, and Go packages. Scores single-maintainer concentration, OIDC gaps, and release consistency — surfacing high-risk dependency patterns that vulnerability databases miss. CLI, GitHub Action, IDE hooks, REST API, and MCP server. Demonstrated predictive scoring on axios and node-ipc before attacks occurred.
```

## Checklist

- [x] Actively maintained
- [x] Free tier available (CLI + GitHub Action)
- [x] Governance/security angle (supply chain trust for agent dependencies)
- [x] Link works
- [x] Alphabetical order within section