### PR TITLE
feat(docs): add MkDocs Material docs site for governance.agentrust-io.com

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - "CNAME"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Configure git for gh-deploy
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Assemble docs build directory
+        run: |
+          BUILD=.docs_build
+          mkdir -p $BUILD
+
+          for fname in README.md CONTRIBUTING.md CNAME; do
+            if [ -f "$fname" ]; then cp "$fname" "$BUILD/$fname"; fi
+          done
+
+          echo "Build dir contains $(find $BUILD -type f | wc -l) files"
+
+      - name: Generate build config
+        run: |
+          sed 's|^docs_dir: \.$|docs_dir: .docs_build|' mkdocs.yml > .mkdocs_build.yml
+
+      - name: Build and deploy to GitHub Pages
+        run: mkdocs gh-deploy --force --clean --config-file .mkdocs_build.yml

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+governance.agentrust-io.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,72 @@
+site_name: Awesome AI Agent Governance
+site_description: A curated list of tools, frameworks, standards, and resources for governing autonomous AI agents
+site_url: https://governance.agentrust-io.com
+repo_url: https://github.com/agentrust-io/awesome-ai-governance
+repo_name: agentrust-io/awesome-ai-governance
+edit_uri: edit/main/
+docs_dir: .
+exclude_docs: |
+  .github/
+  awesome-copilot-contributions/
+  lychee.toml
+  LICENSE
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to light mode
+    - scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to dark mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - toc.follow
+    - header.autohide
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Inter, system-ui, -apple-system, sans-serif
+    code: JetBrains Mono, Cascadia Code, monospace
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - attr_list
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/agentrust-io/awesome-ai-governance
+  generator: false
+
+nav:
+  - List: README.md
+  - Contributing: CONTRIBUTING.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs-material==9.5.49
+mkdocs-minify-plugin==0.8.0


### PR DESCRIPTION
## Summary

- Adds MkDocs Material configuration and GitHub Actions workflow to publish the awesome list at https://governance.agentrust-io.com
- Uses the same build-dir assembly pattern as cmcp and trace-tests
- Adds `CNAME` for the custom domain
- DNS entry (`governance.agentrust-io.com CNAME agentrust-io.github.io`) needs to be added in Cloudflare alongside the other subdomains

## Test plan

- [ ] CI passes
- [ ] Docs workflow deploys successfully to `gh-pages` branch
- [ ] `governance.agentrust-io.com` resolves after DNS entry and Pages domain configuration

Signed-off-by: Imran Siddique <imran.siddique@opaque.co>