### PR TITLE
fix(docs): set cache-dependency-path for pip cache in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+          cache-dependency-path: requirements-docs.txt
 
       - name: Install docs dependencies
         run: pip install -r requirements-docs.txt


### PR DESCRIPTION
The initial docs workflow failed because `actions/setup-python cache: pip` couldn't locate a requirements file at the expected paths. Adding `cache-dependency-path: requirements-docs.txt` points it at the correct file.

Signed-off-by: Imran Siddique <imran.siddique@opaque.co>