### PR TITLE
docs: add brand CSS, fix deps, align workflow with other repos

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "docs/**"
       - "README.md"
       - "CONTRIBUTING.md"
       - "mkdocs.yml"
@@ -46,6 +47,8 @@ jobs:
         run: |
           BUILD=.docs_build
           mkdir -p $BUILD
+
+          if [ -d docs ]; then cp -r docs $BUILD/docs; fi
 
           for fname in README.md CONTRIBUTING.md CNAME; do
             if [ -f "$fname" ]; then cp "$fname" "$BUILD/$fname"; fi

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,182 @@
+/*
+ * Awesome AI Agent Governance — visual theme aligned with agentrust-io repos
+ * Primary brand: violet (#7c3aed), dark gradient header
+ * Font stack: GitHub Primer system fonts
+ */
+
+/* ==========================================================================
+   1. Color tokens
+   ========================================================================== */
+
+:root,
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:              #7c3aed;
+  --md-primary-fg-color--light:       #a78bfa;
+  --md-primary-fg-color--dark:        #5b21b6;
+  --md-accent-fg-color:               #0ea5e9;
+  --md-accent-fg-color--transparent:  rgba(14, 165, 233, 0.10);
+  --md-typeset-a-color:               #7c3aed;
+
+  --md-default-bg-color:              #ffffff;
+  --md-default-bg-color--light:       #f6f8fa;
+
+  --ag-text:        #1f2328;
+  --ag-text-muted:  #59636e;
+  --ag-border:      #d1d9e0;
+  --ag-surface:     #f6f8fa;
+  --ag-code-bg:     #f6f8fa;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:              #818cf8;
+  --md-primary-fg-color--light:       #a5b4fc;
+  --md-primary-fg-color--dark:        #6366f1;
+  --md-accent-fg-color:               #38bdf8;
+  --md-accent-fg-color--transparent:  rgba(56, 189, 248, 0.15);
+  --md-typeset-a-color:               #818cf8;
+
+  --md-default-bg-color:              #0f0a1e;
+  --md-default-bg-color--light:       #1a1033;
+  --md-code-bg-color:                 #1e1533;
+
+  --ag-text:        #f0f6fc;
+  --ag-text-muted:  #9198a1;
+  --ag-border:      #3d2f5c;
+  --ag-surface:     #1a1033;
+  --ag-code-bg:     #1e1533;
+}
+
+
+/* ==========================================================================
+   2. Typography — GitHub Primer system font stack
+   ========================================================================== */
+
+:root {
+  --ag-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --ag-font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+}
+
+body,
+.md-typeset,
+.md-header,
+.md-tabs,
+.md-nav,
+.md-footer {
+  font-family: var(--ag-font-sans);
+}
+
+.md-typeset code,
+.md-typeset pre,
+.md-typeset kbd,
+.md-code__content,
+.highlight pre {
+  font-family: var(--ag-font-mono);
+}
+
+.md-typeset {
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--ag-text);
+}
+
+.md-typeset h1 {
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.25;
+  color: var(--ag-text);
+}
+
+[data-md-color-scheme="slate"] .md-typeset h1 {
+  color: #ffffff;
+}
+
+.md-typeset h2 {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+  border-bottom: 1px solid var(--ag-border);
+  padding-bottom: 0.4rem;
+  margin-top: 2rem;
+}
+
+.md-typeset h3 {
+  font-weight: 600;
+  line-height: 1.25;
+  margin-top: 1.5rem;
+}
+
+
+/* ==========================================================================
+   3. Header — dark gradient
+   ========================================================================== */
+
+.md-header {
+  background: linear-gradient(135deg, #0d0a1f 0%, #071828 100%);
+}
+
+
+/* ==========================================================================
+   4. Navigation
+   ========================================================================== */
+
+.md-nav__title {
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ag-text-muted);
+}
+
+.md-nav__link--active {
+  font-weight: 600;
+  color: var(--md-primary-fg-color) !important;
+}
+
+
+/* ==========================================================================
+   5. Tables — GitHub Primer style
+   ========================================================================== */
+
+.md-typeset table:not([class]) {
+  border-collapse: collapse;
+  width: 100%;
+  border: 1px solid var(--ag-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.md-typeset table:not([class]) th {
+  background-color: var(--ag-surface);
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--ag-text);
+  border-bottom: 1px solid var(--ag-border);
+  padding: 0.5rem 0.75rem;
+}
+
+.md-typeset table:not([class]) td {
+  border-bottom: 1px solid var(--ag-border);
+  padding: 0.5rem 0.75rem;
+  vertical-align: top;
+}
+
+.md-typeset table:not([class]) tr:last-child td {
+  border-bottom: none;
+}
+
+
+/* ==========================================================================
+   6. Footer
+   ========================================================================== */
+
+.md-footer {
+  background-color: var(--ag-surface);
+  border-top: 1px solid var(--ag-border);
+  color: var(--ag-text-muted);
+}
+
+.md-footer-meta {
+  background-color: var(--ag-surface);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,9 @@ extra:
       link: https://github.com/agentrust-io/awesome-ai-governance
   generator: false
 
+extra_css:
+  - docs/stylesheets/extra.css
+
 nav:
   - List: README.md
   - Contributing: CONTRIBUTING.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,4 @@
-mkdocs-material==9.5.49
-mkdocs-minify-plugin==0.8.0
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocs-minify-plugin>=0.8
+pymdown-extensions>=10.7


### PR DESCRIPTION
## Summary

Brings the docs site at governance.agentrust-io.com in line with cmcp and trace-spec.

- **Brand CSS** — adds `docs/stylesheets/extra.css` with the shared violet/dark-gradient theme (color tokens, GitHub Primer font stack, dark header gradient, nav active states, GitHub-style tables, footer). Wires it in via `extra_css` in `mkdocs.yml`.
- **Dependency fix** — `requirements-docs.txt` declared pinned versions but was missing `pymdown-extensions`, which `mkdocs.yml` uses for emoji, highlight, superfences, etc. Switches to `>=` constraints to match the other repos.
- **Workflow alignment** — adds `docs/**` to the push trigger paths and adds a `cp -r docs` step so stylesheets reach the built site.

## Test plan

- [ ] Build passes locally: `mkdocs build` with the assembled build dir succeeds (verified)
- [ ] `governance.agentrust-io.com` shows the violet/dark-gradient header after deploy
- [ ] Light/dark mode toggle works