### PR TITLE
Add AI Agent Incident Register to Industry Reports & Guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 
 *Practitioner guides, threat models, and industry analyses for agent governance.*
 
+- [AI Agent Incident Register](https://companyscope.io/register) - A numbered public corpus of AI agent incidents, each analysed for the legal duty engaged, who bears liability across the chain (deployer / shared / vendor), and the governance that would have prevented it. Includes a Liability Crosswalk mapping OWASP's agentic Top 10, the NIST AI RMF, Singapore's IMDA framework, and the EU AI Act to each other and to who carries liability. Free to read and cite; CC BY 4.0 machine-readable feed.
+
 - [Anthropic's Responsible Scaling Policy](https://www.anthropic.com/responsible-scaling-policy) - Framework for responsible AI deployment with AI Safety Levels (ASL) and safety evaluation commitments.
 - [Anthropic: Trustworthy Agents in Practice](https://www.anthropic.com/research/trustworthy-agents) - Anthropic's practical guidance on deploying trustworthy agents: balancing autonomy with human oversight, prompt-injection resistance, and operational safeguards.
 - [CSA AI Safety Initiative](https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence) - Cloud Security Alliance publications on AI safety and security best practices.


### PR DESCRIPTION
Adds the AI Agent Incident Register: a free public corpus of AI-agent incidents analysed for the legal duty engaged and the liability allocation across the chain (deployer/shared/vendor), plus a Liability Crosswalk mapping OWASP's agentic Top 10, NIST AI RMF, IMDA, and the EU AI Act to one another and to who carries liability. Directly on-topic for agent governance and compliance; CC BY 4.0 feed. Placed in Industry Reports & Guidance — happy to move to Governance Frameworks if you'd prefer.