### PR TITLE
Add VERITAS Omega Agent Trust Lab to Security Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [HouYi](https://github.com/LLMSecurity/HouYi) - Prompt injection attack framework for testing LLM-integrated application security boundaries.
 - [PyRIT](https://github.com/Azure/PyRIT) - Microsoft's Python Risk Identification Toolkit for red-teaming generative AI systems with automated attack strategies.
 - [Snyk Agent Scan](https://github.com/snyk/agent-scan) - Security scanner for AI agents and MCP servers. Detects vulnerabilities in tool configurations, permissions, and data flows.
+- [VERITAS Omega Agent Trust Lab](https://github.com/VrtxOmega/veritas-agent-trust-lab) - Open-source blind calibration lab for testing whether agent-assurance decisions survive forged results, parameter substitution, nonce replay, correlated evaluators, evidence deletion, and missing telemetry.
 
 ## Standards & Specifications
 


### PR DESCRIPTION
## Summary

Add one neutral entry for the open-source VERITAS Omega Agent Trust Lab under
Security Testing.

The lab presents six fixed agent-assurance cases—three clean and three
tampered—covering forged results, parameter substitution, nonce replay,
correlated evaluators, evidence deletion, and missing telemetry. Participants
label all cases before the answers are revealed.

## Scope fit

- Public source: https://github.com/VrtxOmega/veritas-agent-trust-lab
- Live zero-signup challenge: https://vrtxomega.github.io/veritas-agent-trust-lab/
- MIT licensed and actively maintained
- Security-testing focus; it is not a general AI framework or governance manifesto

## Author disclosure

I am the author and maintainer of the submitted project.

## Verification

- source repository: HTTP 200
- live challenge: HTTP 200
- current upstream `main` checked for an existing entry: none found
- open pull requests checked for overlap: none found
- diff: one README line, one commit
- PCF contributor preflight: `ready-for-maintainer`, 100/100

The project does not claim to be an audit, certification, factual-truth engine,
or execution authority.

Assisted-by: OpenAI Codex. I reviewed the final text, links, scope, and diff.
