### PR TITLE
Add Provena to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [LangSmith](https://smith.langchain.com/) - LangChain's platform for debugging, testing, evaluating, and monitoring LLM applications.
 - [MLflow](https://github.com/mlflow/mlflow) - Open-source ML lifecycle platform with experiment tracking, model registry, and LLM evaluation tools.
 - [Prometheus](https://prometheus.io/) + [Grafana](https://grafana.com/) - Industry-standard metrics and visualization. Foundation for custom agent SLO dashboards.
+- [Provena](https://github.com/rajfirke/provena) - Open-source Python library for tamper-evident audit trails of AI agent context inputs: hash-chained logging, provenance validation, and freshness checking, with EU AI Act and OWASP ASI06 compliance reporting.
 - [traceAI](https://github.com/future-agi/traceAI) - Open-source OpenTelemetry-native tracing for LLM and agent apps with 50+ framework integrations.
 - [Weights & Biases](https://wandb.ai/) - ML experiment tracking with LLM tracing, evaluation pipelines, and model monitoring.
 


### PR DESCRIPTION
Disclosure: I'm the author of Provena.

Adds [Provena](https://github.com/rajfirke/provena) (Apache-2.0, `pip install provena`) to the Observability & Monitoring section, alphabetically placed between Prometheus/Grafana and traceAI.

What it does: governs context *inputs* to AI agents rather than tracing their execution -- hash-chained (SHA-256) tamper-evident audit trail, provenance validation, and freshness checking for RAG/tool/memory/MCP context sources, with EU AI Act Art. 10/12/13/14 and OWASP ASI06 compliance reporting. Zero core dependencies, sub-1ms overhead per entry. Framework adapters for LangChain, LlamaIndex, CrewAI, AutoGen, OpenAI Agents SDK, and Google ADK.

Actively maintained, 460+ tests, real external contributors beyond the maintainer. Happy to adjust wording/placement per your judgment.