### PR TITLE
Add Talks & Videos section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [Standards & Specifications](#standards--specifications)
 - [Research Papers](#research-papers)
 - [Industry Reports & Guidance](#industry-reports--guidance)
+- [Talks & Videos](#talks--videos)
 - [Conferences & Communities](#conferences--communities)
 
 ## Governance Frameworks
@@ -184,6 +185,20 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [MITRE ATLAS](https://atlas.mitre.org/) - Adversarial Threat Landscape for AI Systems. Adversary tactics and techniques against AI/ML systems, structured like ATT&CK.
 - [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/) - OWASP's threat catalog and mitigation strategies for agentic applications.
 - [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/) - Top 10 security risks for LLM applications including prompt injection, insecure output handling, and supply chain vulnerabilities.
+
+## Talks & Videos
+
+*Conference talks, keynotes, and recorded sessions on agent governance, runtime enforcement, and hardware-attested execution. Speaker and venue are listed so the source of each claim is visible.*
+
+- [Agentic AI Is Running Your Infrastructure](https://www.youtube.com/watch?v=1Z_7hvy_-YE) - Mike Bursell, Confidential Computing Consortium. Keynote on what changes when agents operate infrastructure rather than assist people, and where confidential computing sits in that trust model. Confidential Computing Summit 2026.
+- [Agentic Zero Trust: at Rest, in Transit, and at Runtime](https://www.youtube.com/watch?v=x7j0D5VYUhw) - N. Polshakova (Solo.io) and J. Halley (Cisco) on extending zero-trust principles to the agent runtime, not just the network. Confidential Computing Summit 2026.
+- [Building Governed AI Agents with the Agent Governance Toolkit](https://www.youtube.com/watch?v=uDQBqp9Om5s) - Imran Siddique (OPAQUE Systems) walking through AGT's policy enforcement and audit model for enterprise deployments. GenAI Gurus, May 2026.
+- [From Trust to Proof: The Next Generation of AI Agent Governance](https://www.youtube.com/watch?v=uz4absejhHc) - Imran Siddique and Jason Lazarski (OPAQUE Systems) on the gap between controlling an agent and proving you controlled it, and how Agent Manifest, cMCP, and TRACE close it. July 2026.
+- [Governing AI Agents at Runtime: Open Source Zero-Trust with AGT](https://www.youtube.com/watch?v=YtjjoPTN0U8) - Imran Siddique on runtime governance for agents moving from demo to production. Ubuntu Summit 26.04, Canonical.
+- [Governing AI Agents at the Hardware Boundary](https://www.youtube.com/watch?v=z8hOZ77iiJo) - Imran Siddique (OPAQUE Systems) on why software-only enforcement has a structural ceiling and what moving the control point into a TEE buys. Confidential Computing Summit 2026.
+- [NVIDIA Confidential Computing Attestation for Next-Generation AI](https://www.youtube.com/watch?v=vzQVZA7veO0) - R. Nertney and S. Gilson (NVIDIA) on GPU attestation and the evidence it produces for AI workloads. Confidential Computing Summit 2026.
+- [Open Source Friday: Governance for AI Agents](https://www.youtube.com/watch?v=bIioEmT2KEM) - Imran Siddique with GitHub on why prompts are not a control surface, plus the practical side of running a fast-growing governance project in the open. June 2026.
+- [Reliability in AI (Agentic) Systems](https://www.youtube.com/watch?v=jvHZAQdx-LU) - Panel on failure modes, evaluation, and what reliability means for systems that act. Confidential Computing Summit 2026.
 
 ## Conferences & Communities
 


### PR DESCRIPTION
@
Adds a `Talks & Videos` section between Industry Reports & Guidance and Conferences & Communities, plus the Contents entry.

Nine entries, each with speaker and venue so attribution is visible rather than implied:

- Confidential Computing Summit 2026: Bursell (CCC), Polshakova/Halley (Solo.io, Cisco), Nertney/Gilson (NVIDIA), the reliability panel, and the hardware-boundary talk
- Ubuntu Summit 26.04 (Canonical)
- Open Source Friday (GitHub)
- GenAI Gurus
- The July 2026 From Trust to Proof session

All links verified live. Mixed speakers and hosts by design, so the section reads as a topic index rather than a single-vendor reel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@