### PR TITLE
chore(ci): pin agentrust-io/.github checkout to an immutable SHA

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -30,7 +30,10 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: agentrust-io/.github
-          ref: 0b440ff18506b879983936b07a76faf06e920a15 # main as of 2026-06-11; bump deliberately
+          # Pinned deliberately: this workflow runs on pull_request_target
+          # with a write-capable token, so the code it checks out must not
+          # track a mutable ref. Bump this SHA after reviewing the diff.
+          ref: 0fe4520ee71a743fcd33f409fe366ee3e1da6f86 # main as of 2026-08-01
           persist-credentials: false
           sparse-checkout: |
             scripts


### PR DESCRIPTION
The contributor-check workflow runs on `pull_request_target` holding
`issues: write` and `pull-requests: write`, and checked out
`agentrust-io/.github` at **`ref: main`** — a mutable ref. Anyone able to land
a commit on that repo's main got a write-capable token in this repo.

The org action's own template comment already says the ref "must not be a
mutable ref". 7 of the 8 consuming repos were doing it anyway. This is one of
8 matching PRs.

Pinned to [`0fe4520`](https://github.com/agentrust-io/.github/commit/0fe4520ee71a743fcd33f409fe366ee3e1da6f86)
(main as of 2026-08-01), which also carries the AGT bump to `359a6b8` and its
fail-closed UNKNOWN risk ordering. At the previous AGT pin, `UNKNOWN` sorted
*below* `LOW`, so a check that errored or hit a GitHub rate limit was silently
scored as clean.

### Cost

Bumping the org action now takes a deliberate PR in each consuming repo. That
is the intended tradeoff, and it goes away if we move the checks to a PyPI
dependency (under discussion) — consumers would then `pip install` a pinned
version and drop the cross-repo checkout entirely.