### PR TITLE
feat: add Microsoft Agent Framework, retitle the Microsoft Responsible AI entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [LangChain](https://github.com/langchain-ai/langchain) - Composable framework with callbacks, tracing, and moderation chains for LLM applications.
 - [LangGraph](https://github.com/langchain-ai/langgraph) - Stateful, multi-actor agent framework with human-in-the-loop and persistence built in.
 - [LlamaIndex](https://github.com/run-llama/llama_index) - Data framework with observability callbacks, evaluation modules, and structured output guarantees.
+- [Microsoft Agent Framework (MAF)](https://github.com/microsoft/agent-framework) - Microsoft's multi-agent orchestration framework for Python and .NET, with migration paths from Semantic Kernel and AutoGen. Governance-relevant pieces are human-in-the-loop workflow steps, checkpointing, and built-in OpenTelemetry tracing.
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) - Official OpenAI SDK with built-in guardrails, input/output validation, and handoff controls.
 - [PydanticAI](https://github.com/pydantic/pydantic-ai) - Agent framework with type-safe tool definitions, structured outputs, and dependency injection.
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel) - Microsoft's AI orchestration SDK with plugin permission models, function filtering, and responsible AI hooks.
@@ -181,7 +182,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [Anthropic: Trustworthy Agents in Practice](https://www.anthropic.com/research/trustworthy-agents) - Anthropic's practical guidance on deploying trustworthy agents: balancing autonomy with human oversight, prompt-injection resistance, and operational safeguards.
 - [CSA AI Safety Initiative](https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence) - Cloud Security Alliance publications on AI safety and security best practices.
 - [Google Secure AI Framework (SAIF)](https://safety.google/cybersecurity-advancements/saif/) - Conceptual framework for securing AI systems across the development and deployment lifecycle.
-- [Microsoft Responsible AI Standard](https://www.microsoft.com/en-us/ai/responsible-ai) - Framework covering fairness, reliability, safety, and transparency in AI development.
+- [Microsoft Responsible AI](https://www.microsoft.com/en-us/ai/responsible-ai) - Hub for Microsoft's responsible AI practice: the six principles, the governance structure behind them, and transparency notes for shipped systems. Links out to the Responsible AI Standard itself, which is a separate document.
 - [MITRE ATLAS](https://atlas.mitre.org/) - Adversarial Threat Landscape for AI Systems. Adversary tactics and techniques against AI/ML systems, structured like ATT&CK.
 - [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/) - OWASP's threat catalog and mitigation strategies for agentic applications.
 - [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/) - Top 10 security risks for LLM applications including prompt injection, insecure output handling, and supply chain vulnerabilities.


### PR DESCRIPTION
Follow-up to #52, which @dradoaica closed without merging after review. You said the MAF addition was a genuine gap and the one you wanted, and their closing comment was "feel free to add the MAF entry directly", so this picks up that entry alone. Credit to them for spotting it.

## MAF entry

Description rewritten rather than copied over. The version in #52 opened with "Successor to Semantic Kernel and AutoGen", which the MAF repository does not claim: it ships separate "Migration from Semantic Kernel" and "Migration from AutoGen" guides and treats them as distinct frameworks. I checked the repo README rather than repeat it.

What the entry says now is what MAF documents, with the governance-relevant features named instead of a generic blurb: human-in-the-loop workflow steps, checkpointing, and built-in OpenTelemetry tracing. Placed alphabetically between LlamaIndex and OpenAI Agents SDK.

## The Microsoft entry retitle

Their parting comment made a fair point that lands on our own content, not theirs:

> the Microsoft Responsible AI entry appears to be mistitled, is not actually a standard, and doesn't match the content of the linked page

That is correct. The entry was titled "Microsoft Responsible AI Standard" while linking to `microsoft.com/en-us/ai/responsible-ai`, which is a practice hub titled "Responsible AI at Microsoft". The Responsible AI Standard is a separate publication that the hub links out to. So the list named a document and pointed somewhere else.

Retitled to match the link, and the description now says what the page actually contains. That old description ("Framework covering fairness, reliability, safety, and transparency in AI development") is also the exact line that got copied into the proposed AWS and GCP entries, which is what made all three indistinguishable in the first place. Worth fixing at the source.

The AWS and GCP entries are deliberately not included, since you declined them.

## Their third point, not addressed here

> it's clear the contributing guidelines could use a bit more detail around what belongs in that section

Also fair, and a separate change. Standards and Frameworks currently mixes published standards, vendor practice hubs, and conceptual frameworks with no stated inclusion rule, which is why two contributors in a row read it differently. Happy to draft that if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)