### PR TITLE
Add 'Preventive vs. Reactive AI Agent Governance' to Industry Reports & Guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [MITRE ATLAS](https://atlas.mitre.org/) - Adversarial Threat Landscape for AI Systems. Adversary tactics and techniques against AI/ML systems, structured like ATT&CK.
 - [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/) - OWASP's threat catalog and mitigation strategies for agentic applications.
 - [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/) - Top 10 security risks for LLM applications including prompt injection, insecure output handling, and supply chain vulnerabilities.
+- [Preventive vs. Reactive AI Agent Governance](https://penholder.ai/preventive-vs-reactive-ai-agent-governance.html) - Comparison of preventive control (gating an agent's write to a system of record behind human approval before it commits) versus reactive governance (detecting and remediating harmful actions after they have executed), and the trade-offs of each model.
 
 ## Talks & Videos
 


### PR DESCRIPTION
### What this adds

One entry at the end of **Industry Reports & Guidance** (after "OWASP Top 10 for LLM Applications", preserving the section's alphabetical block):

`- [Preventive vs. Reactive AI Agent Governance](https://penholder.ai/preventive-vs-reactive-ai-agent-governance.html) - Comparison of preventive control (gating an agent's write to a system of record behind human approval before it commits) versus reactive governance (detecting and remediating harmful actions after they have executed), and the trade-offs of each model.`

### Why it fits

The section collects practitioner guides, threat models, and industry analyses. This is a neutral conceptual analysis of two governance postures for agents that write to a system of record — preventive (approve before the write commits) versus reactive (detect and remediate after) — and the trade-offs of each. Publicly readable, no paywall.

### Notes
- Alphabetical order preserved (Preventive sorts after OWASP).
- Format matched: `- [Name](url) - one-line description.` with a plain-hyphen separator.
- Link verified working (HTTP 200).

### Disclosure
I work on Penholder (built on AnyChart's spreadsheet engine); the article is on the penholder.ai domain, so it's vendor-affiliated — I've kept the description strictly neutral/educational. Happy to adjust the wording or drop it if it isn't a fit.
