### PR TITLE
fix: enforce all repository maintainers

### DIFF
--- a/.github/workflows/require-maintainer-approval.yml
+++ b/.github/workflows/require-maintainer-approval.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const MAINTAINERS = ['imran-siddique'];
+            const MAINTAINERS = ['imran-siddique', 'pforest', 'podcastinator', 'Qiang-Xu'];
 
             // Maintainer-authored PRs skip the gate. author_association is
             // not reliable for this: it only reports MEMBER when the
@@ -40,12 +40,6 @@ jobs:
             const author = context.payload.pull_request.user.login;
             if (MAINTAINERS.includes(author)) {
               core.info(`Author ${author} is a maintainer, skipping gate`);
-              return;
-            }
-
-            const association = context.payload.pull_request.author_association;
-            if (association === 'MEMBER' || association === 'OWNER') {
-              core.info(`Author is ${association}, skipping gate`);
               return;
             }
 


### PR DESCRIPTION
## What changed

- aligns the named maintainer gate with the repository's live `maintain`-role holders plus the organization maintainers team
- removes the broad `MEMBER`/`OWNER` author bypass, so only named maintainers skip their own gate
- adds the gate where the repository did not already carry it

## Why

The workflow had drifted to a single hard-coded maintainer and was not consistently present or enforced. Valid maintainer approvals could fail, while organization membership could bypass the named-maintainer policy.

## Validation

- maintainer arrays mechanically compared with the live GitHub role inventory
- all 15 workflow files parsed with `yaml.safe_load`
- `git diff --check` passed in every repository
