### PR TITLE
Add EU AI Regulation Decoded (obligation-to-evidence resource) to Ind…

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [MITRE ATLAS](https://atlas.mitre.org/) - Adversarial Threat Landscape for AI Systems. Adversary tactics and techniques against AI/ML systems, structured like ATT&CK.
 - [OWASP Agentic AI Threats and Mitigations](https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/) - OWASP's threat catalog and mitigation strategies for agentic applications.
 - [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/) - Top 10 security risks for LLM applications including prompt injection, insecure output handling, and supply chain vulnerabilities.
+- [EU AI Regulation Decoded](https://euaird.vercel.app/) - Practitioner reference mapping EU AI Act obligations to the specific evidence an auditor expects — by role, risk tier, and deadline — with common audit red flags. Includes a free interactive audit-readiness checklist and a CC BY 4.0 machine-readable [obligation-to-evidence dataset](https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset).
 
 ## Talks & Videos
 


### PR DESCRIPTION
Adds **EU AI Regulation Decoded** to *Industry Reports & Guidance*.

It's a free practitioner reference that maps EU AI Act obligations to the specific **evidence** an auditor expects — by role, risk tier, and deadline — plus common audit red flags. It sits naturally alongside the EU AI Act / evidence-oriented resources already listed (the EU AI Act entry, the AI Agent Incident Register, the Singapore Readiness Checklist): teams governing agentic systems for EU AI Act compliance still need to know *what documentation proves each obligation*.

- Live reference + interactive tool: https://euaird.vercel.app/
- Free audit-readiness checklist: https://euaird.vercel.app/audit-readiness.html
- CC BY 4.0 machine-readable dataset (obligation → evidence → red flags): https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset

Not legal advice; every record cites primary sources. Single-line addition, no other changes. Thanks for maintaining this list!