### PR TITLE
Add Fairness & Bias Auditing section (Fair Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [Agent Identity & Attestation](#agent-identity--attestation)
 - [Observability & Monitoring](#observability--monitoring)
 - [Security Testing](#security-testing)
+- [Fairness & Bias Auditing](#fairness--bias-auditing)
 - [Standards & Specifications](#standards--specifications)
 - [Research Papers](#research-papers)
 - [Industry Reports & Guidance](#industry-reports--guidance)
@@ -133,6 +134,12 @@ AI agents now hold real reach: email, CRMs, databases, financial systems. Guardr
 - [HouYi](https://github.com/LLMSecurity/HouYi) - Prompt injection attack framework for testing LLM-integrated application security boundaries.
 - [PyRIT](https://github.com/Azure/PyRIT) - Microsoft's Python Risk Identification Toolkit for red-teaming generative AI systems with automated attack strategies.
 - [Snyk Agent Scan](https://github.com/snyk/agent-scan) - Security scanner for AI agents and MCP servers. Detects vulnerabilities in tool configurations, permissions, and data flows.
+
+## Fairness & Bias Auditing
+
+*Toolkits for auditing AI-driven decision systems for algorithmic bias and measuring the effect of mitigation.*
+
+- [Fair Code](https://github.com/yakew7/Fair-Code) - Audits real-world-style AI decision systems (criminal justice, hiring, lending, insurance, welfare, hospital readmission, tenant screening) for algorithmic bias, pairing a biased baseline with a mitigated version and measured before/after fairness metrics.
 
 ## Standards & Specifications
 


### PR DESCRIPTION
I'm the author of Fair Code and am submitting it for inclusion in this list.

Fair Code (https://github.com/yakew7/Fair-Code, site: thefaircode.xyz) is an open-source project that audits real-world-style AI systems for algorithmic bias across 7 domains: criminal justice (COMPAS), hiring, lending, insurance, welfare, hospital readmission, and tenant screening. Each audit ships a biased baseline model alongside a mitigated version, with measured before/after fairness metrics, Jupyter notebooks, a benchmark harness, and a client-side dataset bias profiler. It's MIT licensed, with 43 stars, 21 forks, and 15 outside contributors.

**Note on scope**: this repo is primarily focused on AI *agent* governance (agent frameworks, LLM guardrails, agent observability/security), and Fair Code isn't agent-specific — it audits classic ML decision systems (classifiers) rather than autonomous agents. I'm flagging this honestly rather than overstating the fit: I think it's adjacent to the repo's usual scope (fairness/bias is a recognized dimension of AI trust and governance, and your own guidelines list "trust angle" as a qualifying criterion alongside governance and safety) rather than squarely inside it. I've proposed a new "Fairness & Bias Auditing" section, placed between Security Testing and Standards & Specifications, since no existing section covers this and I didn't want to force it into an agent-specific category where it doesn't belong. Happy to have this closed if fairness/bias auditing of non-agent systems is considered out of scope for this list — your call.