### PR TITLE
chore: pin line endings so autocrlf stops rewriting whole files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Normalize line endings so a contributor on Windows does not rewrite a whole file.
+# core.autocrlf turned a one-line listing addition into a 240-line diff twice (#57, #65).
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf


### PR DESCRIPTION
Adds a `.gitattributes` pinning markdown and YAML to LF.

## Why

This has now cost two listing PRs their diff. On #57 a contributor's checkout converted three lines; on #65 it converted all 239, so a one-line entry addition landed as a full-README rewrite and `git blame` lost every other line in the file.

Neither was the contributor's doing. `core.autocrlf=true` is the Git for Windows default, so a checkout rewrites LF to CRLF, and anything the contributor saves comes back as a whole-file change. Without a `.gitattributes` there is nothing telling Git what this repository actually wants.

README.md on main is LF today (242 lines, zero CRLF) after #65, so `eol=lf` matches what is already committed and no file changes shape when this lands.

## Scope

`*.md`, `*.yml`, `*.yaml`. No behaviour change, no content change.