### PR TITLE
docs: document sponsorship and editorial independence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 AI agents now hold real reach: email, CRMs, databases, financial systems. Guardrails at the content layer probably hold, but enterprises need to run on proof, not probability. This list tracks the tools and practices for making agents safe, auditable, and trustworthy in production.
 
+Project support is recognized in [SPONSORS.md](SPONSORS.md). Sponsorship is
+separate from inclusion, ordering, editorial judgment, maintainership, and
+project governance; sponsored organizations and their competitors are evaluated
+under the same published contribution criteria.
+
 ## Contents
 
 - [Governance Frameworks](#governance-frameworks)

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,20 @@
+# Sponsors
+
+Awesome AI Agent Governance is a community-curated open-source project.
+Sponsors provide funding, engineering time, infrastructure, or other in-kind
+support. Sponsorship does not confer project ownership, governance authority,
+or control over editorial decisions.
+
+## Current sponsors
+
+### OPAQUE Systems
+
+Founding engineering and infrastructure sponsor, and contributor to the
+AgenTrust ecosystem.
+
+## Editorial independence
+
+Sponsor recognition is separate from inclusion, ordering, descriptions, and
+maintainership. A sponsor's products receive no automatic listing, preferred
+placement, or exception from [CONTRIBUTING.md](CONTRIBUTING.md). Competing
+products are evaluated under the same published criteria.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ extra_css:
 
 nav:
   - List: README.md
+  - Sponsors: SPONSORS.md
   - Contributing: CONTRIBUTING.md
 
 extra_javascript:


### PR DESCRIPTION
## Summary

- add a dedicated sponsor policy and recognition page
- separate sponsorship from inclusion, ordering, and editorial judgment
- apply the same published criteria to sponsors and competitors
- add sponsor information to the documentation site

## Validation

- `git diff --check`