### PR TITLE
Add GOPAL to Policy as Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ under the same published contribution criteria.
 
 - [Casbin](https://github.com/casbin/casbin) - Cross-language authorization library supporting ACL, RBAC, and ABAC models. Available in Go, Python, Java, and more.
 - [Cedar](https://github.com/cedar-policy/cedar) - Amazon's policy language for fine-grained, type-safe access control. Used as the policy engine in the Agent Governance Toolkit. Fast, formally verified, and human-readable.
+- [GOPAL](https://github.com/Principled-Evolution/gopal) - Apache-2.0 library of 85 Rego policies encoding AI-governance regulations (EU AI Act, NIST AI RMF, ICAO/FAA/EASA aviation, FERPA/COPPA, fair lending) as executable allow/deny checks for the OPA engine, versioned per framework with allow/deny tests in CI.
 - [Open Policy Agent (OPA)](https://github.com/open-policy-agent/opa) - CNCF general-purpose policy engine. Decouples policy decisions from application logic using the Rego language. Widely deployed for Kubernetes and API authorization.
 - [SpiceDB](https://github.com/authzed/spicedb) - Google Zanzibar-inspired database for fine-grained, relationship-based authorization. Useful for cross-agent and multi-tenant permission modeling.
 


### PR DESCRIPTION
Disclosure: I maintain GOPAL.

**[GOPAL](https://github.com/Principled-Evolution/gopal)** is an Apache-2.0 library of 85 Rego policies that encode AI-governance regulations as executable allow/deny checks: EU AI Act (29 policies mapped to articles), NIST AI RMF, ICAO/FAA/EASA aviation, FERPA/COPPA, fair lending, healthcare, automotive.

I've put it in **Policy as Code**, next to Open Policy Agent, because that is the honest relationship: OPA is the engine, and GOPAL is a regulation-specific rule library for it. Someone building agent governance on the OPA entry already in that section can pull EU AI Act or NIST AI RMF rules off the shelf instead of writing them.

One thing worth flagging so you can judge placement: the section blurb describes tools for "agent capability bounds, tool access, and data permissions", and GOPAL is not that. It evaluates AI-system metadata, model cards, and eval results against regulatory obligations, which is the compliance side rather than the authorization side. If you would rather it sat in Standards & Specifications alongside the EU AI Act and NIST AI RMF entries, or not at all, that is a fair call and I won't argue it.

Meets the contribution guidelines: open-source (Apache-2.0, `LICENSE` present), actively maintained (commits this week), not a duplicate, and it has a governance angle by construction. Format matches the surrounding entries and it's placed alphabetically. First commit March 2025, 78 commits. Already listed in [awesome-opa](https://github.com/open-policy-agent/awesome-opa), [Awesome Responsible AI](https://github.com/AthenaCore/AwesomeResponsibleAI), and the [OPA ecosystem directory](https://www.openpolicyagent.org/ecosystem/entry/principled-evolution).