### PR TITLE
fix: governance-audit hook broken JSONL format + wrong session counts)

### DIFF
--- a/awesome-copilot-contributions/hooks/governance-audit/README.md
+++ b/awesome-copilot-contributions/hooks/governance-audit/README.md
@@ -84,6 +84,10 @@ Events are written to `logs/copilot/governance/audit.log` in JSON Lines format:
 {"timestamp":"2026-01-15T10:32:00Z","event":"threat_detected","governance_level":"standard","threat_count":1,"threats":[{"category":"privilege_escalation","severity":0.8,"description":"Elevated privileges","evidence":"sudo"}]}
 {"timestamp":"2026-01-15T10:45:00Z","event":"session_end","total_events":12,"threats_detected":1}
 ```
+## Internal Files
+
+- `logs/copilot/governance/audit.log` - append-only JSON Lines audit trail (one JSON object per line).
+- `logs/copilot/governance/.session_marker` - internal bookkeeping file used by the hooks to remember where the current session's log entries begin, so `audit-session-end.sh` can report totals for the current session only instead of every session ever logged. Safe to delete; it is regenerated on the next session start. Already covered by the `logs/` entry recommended in `.gitignore` below.
 
 ## Requirements
 

--- a/awesome-copilot-contributions/hooks/governance-audit/audit-prompt.sh
+++ b/awesome-copilot-contributions/hooks/governance-audit/audit-prompt.sh
@@ -87,7 +87,7 @@ if [[ ${#THREATS_FOUND[@]} -gt 0 ]]; then
     fi
     FIRST=false
 
-    THREATS_JSON+=$(jq -Rn \
+    THREATS_JSON+=$(jq -c -Rn \
       --arg cat "$category" \
       --arg sev "$severity" \
       --arg desc "$description" \
@@ -101,7 +101,7 @@ if [[ ${#THREATS_FOUND[@]} -gt 0 ]]; then
   done
   THREATS_JSON+="]"
 
-  jq -Rn \
+  jq -c -Rn \
     --arg timestamp "$TIMESTAMP" \
     --arg level "$LEVEL" \
     --argjson threats "$THREATS_JSON" \
@@ -121,7 +121,7 @@ if [[ ${#THREATS_FOUND[@]} -gt 0 ]]; then
     exit 1
   fi
 else
-  jq -Rn \
+  jq -c -Rn \
     --arg timestamp "$TIMESTAMP" \
     --arg level "$LEVEL" \
     '{"timestamp":$timestamp,"event":"prompt_scanned","governance_level":$level,"status":"clean"}' \

--- a/awesome-copilot-contributions/hooks/governance-audit/audit-session-end.sh
+++ b/awesome-copilot-contributions/hooks/governance-audit/audit-session-end.sh
@@ -10,17 +10,18 @@ fi
 
 INPUT=$(cat)
 
-mkdir -p logs/copilot/governance
+MARKER_FILE="logs/copilot/governance/.session_marker"
 
-TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-LOG_FILE="logs/copilot/governance/audit.log"
+MARKER=0
+if [[ -f "$MARKER_FILE" ]]; then
+  MARKER=$(cat "$MARKER_FILE" 2>/dev/null || echo 0)
+fi
 
-# Count events from this session
 TOTAL=0
 THREATS=0
 if [[ -f "$LOG_FILE" ]]; then
-  TOTAL=$(wc -l < "$LOG_FILE" 2>/dev/null || echo 0)
-  THREATS=$(grep -c '"threat_detected"' "$LOG_FILE" 2>/dev/null || echo 0)
+  TOTAL=$(tail -n +"$((MARKER + 1))" "$LOG_FILE" | grep -c '"event"' || true)
+  THREATS=$(tail -n +"$((MARKER + 1))" "$LOG_FILE" | grep -c '"threat_detected"' || true)
 fi
 
 jq -Rn \

--- a/awesome-copilot-contributions/hooks/governance-audit/audit-session-end.sh
+++ b/awesome-copilot-contributions/hooks/governance-audit/audit-session-end.sh
@@ -10,6 +10,10 @@ fi
 
 INPUT=$(cat)
 
+mkdir -p logs/copilot/governance
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+LOG_FILE="logs/copilot/governance/audit.log"
 MARKER_FILE="logs/copilot/governance/.session_marker"
 
 MARKER=0
@@ -24,7 +28,7 @@ if [[ -f "$LOG_FILE" ]]; then
   THREATS=$(tail -n +"$((MARKER + 1))" "$LOG_FILE" | grep -c '"threat_detected"' || true)
 fi
 
-jq -Rn \
+jq -c -Rn \
   --arg timestamp "$TIMESTAMP" \
   --argjson total "$TOTAL" \
   --argjson threats "$THREATS" \

--- a/awesome-copilot-contributions/hooks/governance-audit/audit-session-start.sh
+++ b/awesome-copilot-contributions/hooks/governance-audit/audit-session-start.sh
@@ -14,7 +14,7 @@ mkdir -p logs/copilot/governance
 
 LOG_FILE="logs/copilot/governance/audit.log"
 MARKER_FILE="logs/copilot/governance/.session_marker"
-...
+
 # Record the line count BEFORE this session's own event is appended, so
 # audit-session-end.sh can compute stats scoped to only this session
 # instead of the whole (cumulative, multi-session) log file.
@@ -28,7 +28,7 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 CWD=$(pwd)
 LEVEL="${GOVERNANCE_LEVEL:-standard}"
 
-jq -Rn \
+jq -c -Rn \
   --arg timestamp "$TIMESTAMP" \
   --arg cwd "$CWD" \
   --arg level "$LEVEL" \

--- a/awesome-copilot-contributions/hooks/governance-audit/audit-session-start.sh
+++ b/awesome-copilot-contributions/hooks/governance-audit/audit-session-start.sh
@@ -12,6 +12,18 @@ INPUT=$(cat)
 
 mkdir -p logs/copilot/governance
 
+LOG_FILE="logs/copilot/governance/audit.log"
+MARKER_FILE="logs/copilot/governance/.session_marker"
+...
+# Record the line count BEFORE this session's own event is appended, so
+# audit-session-end.sh can compute stats scoped to only this session
+# instead of the whole (cumulative, multi-session) log file.
+if [[ -f "$LOG_FILE" ]]; then
+  wc -l < "$LOG_FILE" > "$MARKER_FILE"
+else
+  echo 0 > "$MARKER_FILE"
+fi
+
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 CWD=$(pwd)
 LEVEL="${GOVERNANCE_LEVEL:-standard}"


### PR DESCRIPTION
This PR fixes two bugs in the governance-audit hooks. First, all the jq calls were missing the -c flag, so instead of writing one JSON object per line (proper JSON Lines format, as the README describes), each event got pretty-printed across multiple lines which also silently broke the wc -l based event counting. Second, audit-session-end.sh was counting total_events/threats_detected from the entire cumulative audit.log instead of just the current session, so a completely clean session would still report threats detected in some unrelated past session. Tested manually across multiple simulated sessions (clean and with threats) logs are now valid JSONL and per-session counts are accurate; also ran shellcheck with no errors. No changes to the actual threat-detection patterns or blocking behavior.